### PR TITLE
Add comment to buffer.py

### DIFF
--- a/buffer.py
+++ b/buffer.py
@@ -106,6 +106,10 @@ class TapeBuffer(ReplayBufferBase):
         rng = np.random.default_rng(jax.random.bits(key).item())
         count = 0
         while count < size:
+            # The following few lines cause a known bug where the 3 latest episodes
+            # are excluded from sampling. I leave the bug as-is so my experiments
+            # can be reproduced. Please see https://github.com/proroklab/memoroids/issues/1
+            # for a fix.
             start_idx = rng.integers(len(self.episode_starts) - 1 - 1)
             start = self.episode_starts[start_idx]
             end = self.episode_starts[start_idx + 1]


### PR DESCRIPTION
Tianwei noticed a bug in the tape buffer (https://github.com/proroklab/memoroids/issues/1) where the latest three episodes are not considered during sampling. This adds a comment so that other users can implement a more correct version, while still allowing readers to reproduce experiments from the paper.